### PR TITLE
Update Android Gradle build version and Kotlin version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'io.alexrintt.sharedstorage'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.8.10'
     repositories {
         google()
         jcenter()
@@ -10,7 +10,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:4.1.0"
+        classpath "com.android.tools.build:gradle:7.4.1"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip


### PR DESCRIPTION
The current Kotlin version is too old to be supported with the newer Android Gradle build version (`com.android.tools.build:gradle`). When Android Gradle build version 7.3.0 and above is used, the current Kotlin version in the package (`ext.kotlin_version = '1.3.50'`) is no longer supported as starting from Android Gradle build version 7.3.0 and above requires Kotlin version 1.5.20 and above. 