### PR TITLE
Update Storage Access Framework.md

### DIFF
--- a/docs/Usage/Storage Access Framework.md
+++ b/docs/Usage/Storage Access Framework.md
@@ -7,8 +7,8 @@ import 'package:shared_storage/shared_storage.dart' as saf;
 Usage sample:
 
 ```dart
-shared_storage.openDocumentTree(...);
-shared_storage.listFiles(...);
+saf.openDocumentTree(...);
+saf.listFiles(...);
 ```
 
 But if you import without alias `import '...';` (Not recommeded because can conflict with other method/package names) you should use directly as functions:


### PR DESCRIPTION
As per the import example, it has a import prefix `saf`. I guess `saf.<func>` is intended.